### PR TITLE
Update to new URL in atom-dark-ui repo

### DIFF
--- a/styles/minimap-git-diff.less
+++ b/styles/minimap-git-diff.less
@@ -1,6 +1,6 @@
 // The ui-variables file is provided by base themes provided by Atom.
 //
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
+// See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
 @import "syntax-variables";


### PR DESCRIPTION
`https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less` is correct, the old URL 404s 